### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: ["master"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/artonge/meteo/security/code-scanning/1](https://github.com/artonge/meteo/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block limiting the GITHUB_TOKEN to the minimum needed. For this workflow, the `build` job only needs to read repository contents to check out the code; upload-pages-artifact does not require additional write scopes. The `deploy` job already has its own `permissions` block, so we can safely set a restrictive default at the workflow level that applies to `build` without altering `deploy`.

The best way to fix this without changing functionality is to add a workflow-level `permissions` block with `contents: read` directly under the `on:` block. This sets the default permissions for all jobs to read-only repository contents. Because `deploy` already defines its own `permissions`, it will override the workflow default and remain unchanged. Concretely, in `.github/workflows/build.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block. No imports or additional definitions are required; this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
